### PR TITLE
Add mondo-toshl integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [TeamCash](https://github.com/elliotdavies/mondo-hackday) - a smart spending tracker for small teams and businesses
 - [mondo-bills](https://github.com/danpalmer/mondo-bills) - service to monitor subscriptions and bills coming out of your Mondo account automatically
 - [bitmondo](https://github.com/ondrejsika/bitmondo) - Show Bitcoin transactions at Mondo feed
+- [Toshl](https://github.com/andreagrandi/mondo-toshl) - Automatically add expenses to Toshl whenever there is a transaction on Mondo card
 
 ## Hardware
 


### PR DESCRIPTION
Add mondo-toshl link. mondo-toshl is an integration with Toshl expenses manager. Whenever an expense or a refund happens on Mondo card, it's automatically added to Toshl account.
