### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 ##### Crystal
 
-- [crystal-mondo](https://github.com/barisbalic/crystal-mondo) - A simple wrapper for the Mondo API
+- [crystal-monzo](https://github.com/barisbalic/crystal-monzo) - A simple wrapper for the Monzo API
 
 ##### Elixir
 - [mondo_elixir](https://github.com/stevedomin/mondo_elixir) - An Elixir client for the Mondo API


### PR DESCRIPTION
As Mondo have now become Monzo, I thought it appropriate to rename the Crystal client.

After merging this PR the README will:
- Reference the correct name and URL for crystal-monzo