### PR TITLE
Add hubot-monzo-me

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Toshl](https://github.com/andreagrandi/mondo-toshl) - Automatically add expenses to Toshl whenever there is a transaction on Mondo card
 - [Uber](https://github.com/rdingwall/hackathon-uber-mondo) - Instant publishing of Uber receipts to your Mondo bank feed
 - [YNAB](https://github.com/scottrobertson/mondo-to-ynab) - Automatically push Mondo transactions to YNAB
+- [hubot-monzo-me](https://github.com/robinjmurphy/hubot-monzo-me) - Quickly generate Monzo.me URLs in chat
 
 ## Hardware
 


### PR DESCRIPTION
It's a simple [Hubot](https://hubot.github.com/) script that makes it easy to generate Monzo.me URLs.

```
RobinM: monzo me £2.50 for coffee
Hubot: https://monzo.me/robinmurphy/2.50?d=Coffee
```

https://github.com/robinjmurphy/hubot-monzo-me