### PR TITLE
Add Monzo Vapor Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ##### Swift
 - [MondoKit](https://github.com/pollarm/MondoKit) - A Swift framework for accessing the Mondo bank API
 - [monzo-swift](https://github.com/marius-serban/monzo-swift) - A server-side Swift package for interacting with the Monzo public API
+- [monzo-vapor](https://github.com/Sherlouk/monzo-vapor) - Swift Package for Server-Side Swift Projects Using Vapor
 
 ## Integrations
 


### PR DESCRIPTION
Adds a link to https://github.com/Sherlouk/monzo-vapor which is a Swift package using Vapor to assist with communicating with the public Monzo API