### PR TITLE
Add monzo-webhook-lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 ##### Go
 - [go-mondo](https://github.com/sjwhitworth/go-mondo) - Provides Go bindings for the Mondo banking app
 - [mondo](https://github.com/icio/mondo) - Golang Mondo API Client
+- [monzo-webhook-lambda](https://github.com/mattrco/monzo-webhook-lambda) - Trigger an AWS Lambda function from a webhook request 
 
 ##### Haskell
 - [monzo](https://hackage.haskell.org/package/monzo) - Haskell bindings for the Monzo API


### PR DESCRIPTION
Lambda function that receives and parses monzo webhook requests. Includes Terraform config for easy setup.